### PR TITLE
Fix from LOM mass-use

### DIFF
--- a/src/views/FooterComponent.vue
+++ b/src/views/FooterComponent.vue
@@ -26,7 +26,7 @@
               <a
                 class="fr-footer__content-link"
                 title="Contactez-nous"
-                href="#"
+                href="mailto:schema@data.gouv.fr"
               >
               {{ $t("footer.contact") }}
               </a>


### PR DESCRIPTION
- [x] fix: mail redirection on contact us
- [ ] restore la Marianne as favicon
- [ ] investigate the multiple quotes issue (often reported by producers, columns look like `""sirenDeclarant""`)
- [ ] investigate glitch that may enable creating an empty dataset (maybe if the resource is not valid, API call could be too early?)